### PR TITLE
[83] Remove Duplicates From Sorted List

### DIFF
--- a/hyeontaek/DeleteDuplicates.java
+++ b/hyeontaek/DeleteDuplicates.java
@@ -1,0 +1,49 @@
+package hyeontaek;
+
+public class DeleteDuplicates {
+
+    public static class ListNode {
+        int val;
+        ListNode next;
+
+        ListNode() {
+        }
+
+        ListNode(int val) {
+            this.val = val;
+        }
+
+        ListNode(int val, ListNode next) {
+            this.val = val;
+            this.next = next;
+        }
+
+      public String toString() {
+        if (next == null) {
+          return val + "";
+        }
+        return val + " -> " + next;
+      }
+    }
+
+    public ListNode deleteDuplicates(ListNode head) {
+        ListNode current = head;
+
+        while (current != null && current.next != null) {
+            if (current.val == current.next.val) {
+                current.next = current.next.next;
+            } else {
+                current = current.next;
+            }
+        }
+
+        return head;
+    }
+
+  public static void main(String[] args) {
+    DeleteDuplicates solution = new DeleteDuplicates();
+    ListNode head = new ListNode(1, new ListNode(1, new ListNode(2, new ListNode(3, new ListNode(3)))));
+    System.out.println(solution.deleteDuplicates(head));
+  }
+
+}


### PR DESCRIPTION
<!-- PR 제목은 ex) [number]-title  -->
<!-- 이름-몇번째(푼 문제 개수) ex) 홍길동-13 -->

# [83] Remove Duplicates From Sorted List
## 문제 설명

Given the head of a sorted linked list, delete all duplicates such that each element appears only
once. Return the linked list sorted as well.

### Example
> Input: head = [1,1,2] \
Output: [1,2]

## 코드 설명

```
public ListNode deleteDuplicates(ListNode head) {
        ListNode current = head;

        while (current != null && current.next != null) {
            if (current.val == current.next.val) {
                current.next = current.next.next;
            } else {
                current = current.next;
            }
        }

        return head;
    }
```

`ListNode current = head;` 현재 노드를 가리키는 포인터 `current`를 리스트의 첫 번째 노드인 `head`로 초기화합니다.

`while (current != null && current.next != null) {` `curren`t가 `null`이 아니고, `current`의 다음 노드도 `null`이 아닌 동안 반복합니다. 이 조건은 리스트의 끝에 도달하거나, 마지막 노드를 처리할 때 반복을 멈추게 합니다.

`if (current.val == current.next.val) {` 현재 노드의 값과 다음 노드의 값이 같은 경우, 즉 중복이 발견된 경우,

`current.next = current.next.next;`현재 노드의 `next` 포인터를 다음 다음 노드`(current.next.next)`로 변경합니다. 이로써 현재 노드와 바로 다음 노드 사이의 연결을 끊고, 중복된 노드를 건너뛰어 제거합니다.
`else {` 중복이 발견되지 않은 경우,
`current = current.next;` `current`를 다음 노드로 이동시킵니다. 이는 중복이 없을 때만 다음 노드로 넘어가게 하여, 연속된 중복된 노드들을 모두 제거할 수 있게 합니다.

`return head;` 수정된 연결 리스트의 `head`를 반환합니다. 중복 제거 과정은 리스트의 구조를 변경하지만, 첫 번째 노드의 위치는 변경되지 않습니다.