### PR TITLE
[112] Path Sum

### DIFF
--- a/hyeontaek/PathSum.java
+++ b/hyeontaek/PathSum.java
@@ -1,0 +1,36 @@
+package hyeontaek;
+
+public class PathSum {
+
+
+  public static class TreeNode {
+    int val;
+    TreeNode left;
+    TreeNode right;
+    TreeNode() {}
+    TreeNode(int val) { this.val = val; }
+    TreeNode(int val, TreeNode left, TreeNode right) {
+      this.val = val;
+      this.left = left;
+      this.right = right;
+    }
+    public String toString() {
+      return String.format("{%s, %s, %s}", val, left, right);
+    }
+  }
+
+  public boolean hasPathSum(TreeNode root, int targetSum) {
+
+    if(root == null) return false;
+    if(root.left == null && root.right == null) return targetSum == root.val;
+    return hasPathSum(root.left, targetSum - root.val) || hasPathSum(root.right, targetSum - root.val);
+  }
+
+  public static void main(String[] args) {
+    TreeNode root = new TreeNode(5, new TreeNode(4, new TreeNode(11, new TreeNode(7), new TreeNode(2)), null), new TreeNode(8, new TreeNode(13), new TreeNode(4, null, new TreeNode(1))));
+    PathSum solution = new PathSum();
+    System.out.println(solution.hasPathSum(root, 22));
+    System.out.println(root);
+  }
+
+}


### PR DESCRIPTION
<!-- PR 제목은 ex) [number]-title  -->
<!-- 이름-몇번째(푼 문제 개수) ex) 홍길동-13 -->

# [112] Path Sum

## 문제 설명

Given the root of a binary tree and an integer targetSum, return true if the tree has a root-to-leaf path such that adding up all the values along the path equals targetSum.

A leaf is a node with no children.

### Example
>Input: root = [5,4,8,11,null,13,4,7,2,null,null,null,1], targetSum = 22 \
Output: true \
Explanation: The root-to-leaf path with the target sum is shown.

## 코드 설명

```
  public boolean hasPathSum(TreeNode root, int targetSum) {

    if(root == null) return false;
    if(root.left == null && root.right == null) return targetSum == root.val;
    return hasPathSum(root.left, targetSum - root.val) || hasPathSum(root.right, targetSum - root.val);
  }
```
`if(root == null) return false;`
현재 노드가 `null`인 경우, 트리가 비어있거나 잎 노드의 자식인 경우이므로, 경로 합이 존재할 수 없으므로 `false`를 반환합니다.

`if(root.left == null && root.right == null) return targetSum == root.val;`
현재 노드가 리프 노드인 경우(즉, 왼쪽과 오른쪽 자식 노드가 모두 `null`인 경우), 현재 노드의 값이 남은 `targetSum`과 같은지 확인합니다. 만약 같다면, 주어진 목표 합을 만족하는 경로를 찾은 것이므로 true를 반환합니다.

`return hasPathSum(root.left, targetSum - root.val) || hasPathSum(root.right, targetSum - root.val);`
현재 노드가 리프 노드가 아닌 경우, 현재 노드의 값을 `targetSum`에서 빼고, 남은 합으로 왼쪽 자식 노드와 오른쪽 자식 노드 각각에 대해 재귀적으로 `hasPathSum` 함수를 호출합니다.
왼쪽 또는 오른쪽 자식 노드 중 하나라도 목표 합을 만족하는 경로를 찾으면 `true`를 반환합니다. 즉, 두 재귀 호출 중 하나라도 `true`를 반환하면, 전체 함수는 `true`를 반환합니다.