### PR TITLE
[112]Path Sum

### DIFF
--- a/dlek-user/[112]Path_Sum
+++ b/dlek-user/[112]Path_Sum
@@ -1,0 +1,13 @@
+class Solution {
+    public boolean hasPathSum(TreeNode root, int targetSum) {
+        if (root == null) {
+            return false;
+        }
+        
+        if (root.left == null && root.right == null) {
+            return root.val == targetSum;
+        }
+
+        return hasPathSum(root.left, targetSum - root.val) || hasPathSum(root.right, targetSum - root.val); 
+    }
+}


### PR DESCRIPTION
# [112]Path Sum

##  문제 설명 

Given the `root` of a binary tree and an integer `targetSum`, return `true` if the tree has a root-to-leaf path such that adding up all the values along the path equals `targetSum`.

A leaf is a node with no children.

 

#### Example 1:
> Input: root = [5,4,8,11,null,13,4,7,2,null,null,null,1], targetSum = 22
> Output: true
> Explanation: The root-to-leaf path with the target sum is shown.

#### Example 2:
> Input: root = [1,2,3], targetSum = 5
> Output: false
> Explanation: There two root-to-leaf paths in the tree:
> (1 --> 2): The sum is 3.
> (1 --> 3): The sum is 4.
> There is no root-to-leaf path with sum = 5.

#### Example 3:

> Input: root = [], targetSum = 0
> Output: false
> Explanation: Since the tree is empty, there are no root-to-leaf paths.

## 코드 설명

```
class Solution {
    public boolean hasPathSum(TreeNode root, int targetSum) {
        if (root == null) {
            return false;
        }

        if (root.left == null && root.right == null) {
            return root.val == targetSum;
        }

        return hasPathSum(root.left, targetSum - root.val) || hasPathSum(root.right, targetSum - root.val); 
    }
}
```
#

```
if (root == null) {
    return false;
}
```
Base case: 만약 루트가 null이면, 경로가 없으므로 false를 반환합니다.



```
if (root.left == null && root.right == null) {
    return root.val == targetSum;
}
```
만약 현재 노드가 리프 노드이면서, 해당 노드의 값이 주어진 targetSum과 같다면 true를 반환합니다.

```
return hasPathSum(root.left, targetSum - root.val) || hasPathSum(root.right, targetSum - root.val); 

```
현재 노드가 리프 노드가 아니라면, 왼쪽 자식 노드와 오른쪽 자식 노드를 재귀적으로 호출하여 각각의 자식 노드에서 targetSum에서 현재 노드의 값을 뺀 값을 탐색합니다.
어느 한쪽이라도 true를 반환하면 해당 경로에서 targetSum을 만들 수 있으므로 true를 반환합니다.
양쪽 모두 false를 반환한다면 해당 경로에서는 targetSum을 만들 수 없으므로 false를 반환합니다.
        


