### PR TITLE
[203] Remove Linked List Elements

### DIFF
--- a/hyeontaek/RemoveLinkedListElements.java
+++ b/hyeontaek/RemoveLinkedListElements.java
@@ -1,0 +1,32 @@
+package hyeontaek;
+
+public class RemoveLinkedListElements {
+
+  public static class ListNode {
+    int val;
+    ListNode next;
+    ListNode() {}
+    ListNode(int val) { this.val = val; }
+    ListNode(int val, ListNode next) { this.val = val; this.next = next; }
+
+    public String toString() {
+      return val + " -> " + next;
+    }
+  }
+
+  public ListNode removeElements(ListNode head, int val) {
+    if (head == null) return null;
+
+    if (head.val == val) return removeElements(head.next, val);
+
+    head.next = removeElements(head.next, val);
+
+    return head;
+  }
+  public static void main(String[] args) {
+    ListNode head = new ListNode(1, new ListNode(2, new ListNode(6, new ListNode(3, new ListNode(4, new ListNode(5, new ListNode(6)))))));
+    RemoveLinkedListElements solution = new RemoveLinkedListElements();
+    ListNode result = solution.removeElements(head, 6);
+    System.out.println(result);
+  }
+}


### PR DESCRIPTION
<!-- PR 제목은 ex) [number]-title  -->
<!-- 이름-몇번째(푼 문제 개수) ex) 홍길동-13 -->

# [203] Remove Linked List Elements

## 문제 설명

Given the head of a linked list and an integer val, remove all the nodes of the linked list that has Node.val == val, and return the new head.

### Example
> Input: head = [1,2,6,3,4,5,6], val = 6 \
Output: [1,2,3,4,5]

## 코드 설명

```java
public ListNode removeElements(ListNode head, int val) {
  if (head == null) {
    return null;
  }

  if (head.val == val) {
    return removeElements(head.next, val);
  }

  head.next = removeElements(head.next, val);

  return head;
}
```

기저 조건:
`if (head == null) { return null; }`
리스트가 비어 있는 경우(즉, `head가 null`인 경우), 더 이상 탐색할 노드가 없으므로 `null`을 반환합니다.

현재 노드의 값이 제거할 값과 같은 경우:
`if (head.val == val) { return removeElements(head.next, val); }`
현재 노드의 값이 제거할 값 `val`과 같은 경우, 현재 노드를 제거하고, 다음 노드를 기준으로 재귀 호출합니다. 이 때, 현재 노드는 리스트에서 제외되며, 다음 노드부터 다시
탐색을 시작합니다.
현재 노드의 값이 제거할 값과 다른 경우:
`head.next = removeElements(head.next, val);`
현재 노드의 값이 제거할 값 val과 다른 경우, 현재 노드는 유지하고, 다음 노드에 대해 재귀 호출을 진행합니다. 재귀 호출의 결과로 반환된 노드를 현재 노드의 `next`로
설정합니다. 이는 다음 노드에서 제거 작업을 처리하고, 그 결과를 현재 노드와 연결하는 역할을 합니다.
현재 노드 반환:
`return head;`
현재 노드를 반환합니다. 앞서 설명한 재귀 호출을 통해 연결 리스트의 앞쪽부터 순차적으로 노드가 연결되며, 최종적으로 변경된 리스트의 헤드 노드가 반환됩니다.
