### PR TITLE
[203] Remove Linked List Elements

### DIFF
--- a/dlek-user/[203] Remove Linked List Elements
+++ b/dlek-user/[203] Remove Linked List Elements
@@ -1,0 +1,18 @@
+class Solution {
+    public ListNode removeElements(ListNode head, int val) {
+        ListNode dummy = new ListNode(0);
+        dummy.next = head;
+        
+        ListNode current = dummy;
+        
+        while (current.next != null) {
+            if (current.next.val == val) {
+                current.next = current.next.next;
+            } else {
+                current = current.next;
+            }
+        }
+        
+        return dummy.next;
+    }
+}


### PR DESCRIPTION

# [203] Remove Linked List Elements

##  문제 설명 

Given the head of a linked list and an integer `val`, remove all the nodes of the linked list that has `Node.val == val`, and return _the new head_.

 

#### Example 1:

> Input: head = [1,2,6,3,4,5,6], val = 6
> Output: [1,2,3,4,5]

#### Example 2:
> Input: head = [], val = 1
> Output: []

#### Example 3:
> Input: head = [7,7,7,7], val = 7
> Output: []

## 코드 설명

```
class Solution {
    public ListNode removeElements(ListNode head, int val) {
        ListNode dummy = new ListNode(0);
        dummy.next = head;

        ListNode current = dummy;

        while (current.next != null) {
            if (current.next.val == val) {
                current.next = current.next.next;
            } else {
                current = current.next;
            }
        }

        return dummy.next;
    }
}
```
#

```
ListNode dummy = new ListNode(0);
dummy.next = head;
```
더미 노드를 생성하고, 더미 노드의 다음을 현재 리스트의 머리로 설정합니다.
더미 노드는 리스트의 시작 부분을 처리하는 데 도움이 됩니다.
```
ListNode current = dummy;
```
현재 노드를 가리키는 포인터 current를 더미 노드로 초기화합니다.
```
while (current.next != null)
```
current.next가 null이 아닐 때까지 반복합니다.
```
current.next = current.next.next;
```
다음 노드를 건너뜁니다. 이는 노드를 제거하는 효과를 가집니다.

