### PR TITLE
[303] Range Sum Query-Immutable

### DIFF
--- a/dlek-user/[303] Range Sum Query-Immutable
+++ b/dlek-user/[303] Range Sum Query-Immutable
@@ -1,0 +1,14 @@
+class NumArray {
+    private int[] sum;
+
+    public NumArray(int[] nums) {
+        sum = new int[nums.length + 1];
+        for (int i = 0; i < nums.length; i++) {
+            sum[i + 1] = sum[i] + nums[i];
+        }
+    }
+
+    public int sumRange(int left, int right) {
+        return sum[right + 1] - sum[left];
+    }
+}


### PR DESCRIPTION

# [303] Range Sum Query-Immutable

## 문제 설명 

Given an integer array `nums`, handle multiple queries of the following type:

1. Calculate the sum of the elements of `nums` between indices `left` and `right` inclusive where `left <= right`.

- Implement the `NumArray` class:

- `NumArray(int[] nums)` Initializes the object with the integer array `nums`.

- `int sumRange(int left, int right)` Returns the sum of the elements of nums between indices `left` and `right` inclusive (i.e. `nums[left] + nums[left + 1] + ... + nums[right]`).

 

#### Example 1:

> Input
> ["NumArray", "sumRange", "sumRange", "sumRange"]
> [[[-2, 0, 3, -5, 2, -1]], [0, 2], [2, 5], [0, 5]]
> Output
> [null, 1, -1, -3]
> 
> Explanation
> NumArray numArray = new NumArray([-2, 0, 3, -5, 2, -1]);
> numArray.sumRange(0, 2); // return (-2) + 0 + 3 = 1
> numArray.sumRange(2, 5); // return 3 + (-5) + 2 + (-1) = -1
> numArray.sumRange(0, 5); // return (-2) + 0 + 3 + (-5) + 2 + (-1) = -3

## 코드 설명

```
class NumArray {
    private int[] sum;

    public NumArray(int[] nums) {
        sum = new int[nums.length + 1];
        for (int i = 0; i < nums.length; i++) {
            sum[i + 1] = sum[i] + nums[i];
        }
    }

    public int sumRange(int left, int right) {
        return sum[right + 1] - sum[left];
    }
}
```
#
```
public NumArray(int[] nums) {```}
```
생성자: 주어진 배열로 누적 합 배열을 초기화합니다.

```
sum = new int[nums.length + 1];
```
누적 합 배열의 크기는 nums의 크기보다 1만큼 큽니다.

```
sum[i + 1] = sum[i] + nums[i];
```
누적 합 계산

```
public int sumRange(int left, int right) {```}
```
주어진 구간의 합을 반환합니다.

```
return sum[right + 1] - sum[left];
```
누적 합 배열을 이용하여 구간 합 계산

