### PR TITLE
[463] Island Perimeter

### DIFF
--- a/dlek-user/[463] Island Perimeter
+++ b/dlek-user/[463] Island Perimeter
@@ -1,0 +1,23 @@
+class Solution {
+    public int islandPerimeter(int[][] grid) {
+        int perimeter = 0;
+
+        for (int i = 0; i < grid.length; i++) {
+            for (int j = 0; j < grid[i].length; j++) {
+                if (grid[i][j] == 1) {
+                    perimeter += 4;
+                    
+                    if (i > 0 && grid[i-1][j] == 1) {
+                        perimeter -= 2;
+                    }
+                    
+                    if (j > 0 && grid[i][j-1] == 1) {
+                        perimeter -= 2;
+                    }
+                }
+            }
+        }
+
+        return perimeter;
+    }
+}


### PR DESCRIPTION

# [463] Island Perimeter

## 문제 설명 

You are given `row x col` `grid` representing a map where `grid[i][j] = 1` represents land and `grid[i][j] = 0` represents water.

Grid cells are connected **horizontally/vertically** (not diagonally). The `grid` is completely surrounded by water, and there is exactly one island (i.e., one or more connected land cells).

The island doesn't have "lakes", meaning the water inside isn't connected to the water around the island. One cell is a square with side length 1. The grid is rectangular, width and height don't exceed 100. Determine the perimeter of the island.

 

#### Example 1:


> Input: grid = [[0,1,0,0],[1,1,1,0],[0,1,0,0],[1,1,0,0]]
> Output: 16
> Explanation: The perimeter is the 16 yellow stripes in the image above.

#### Example 2:

> Input: grid = [[1]]
> Output: 4

#### Example 3:

> Input: grid = [[1,0]]
> Output: 4

## 코드 설명

```
class Solution {
    public int islandPerimeter(int[][] grid) {
        int perimeter = 0;

        for (int i = 0; i < grid.length; i++) {
            for (int j = 0; j < grid[i].length; j++) {
                if (grid[i][j] == 1) {
                    perimeter += 4;

                    if (i > 0 && grid[i-1][j] == 1) {
                        perimeter -= 2;
                    }

                    if (j > 0 && grid[i][j-1] == 1) {
                        perimeter -= 2;
                    }
                }
            }
        }

        return perimeter;
    }
}
```
#
```
int perimeter = 0;
```
perimeter 변수를 초기화하여 섬의 둘레를 저장할 것입니다.


```
for (int i = 0; i < grid.length; i++) {
      for (int j = 0; j < grid[i].length; j++) {
```
2중 for 루프를 사용하여 grid의 각 셀을 탐색합니다.


```
if (grid[i][j] == 1) {
    perimeter += 4;
```
현재 셀이 땅(1)인 경우, 초기 둘레를 4로 증가시킵니다.
grid[i][j] == 1 조건을 확인하여 현재 셀이 땅인지 판단합니다.



```
if (i > 0 && grid[i-1][j] == 1) {
    perimeter -= 2;
}

if (j > 0 && grid[i][j-1] == 1) {
    perimeter -= 2;
}
```
상단 이웃 셀이 땅인 경우(i > 0 && grid[i-1][j] == 1), 둘레를 2 감소시킵니다.
좌측 이웃 셀이 땅인 경우(j > 0 && grid[i][j-1] == 1), 둘레를 2 감소시킵니다.
각 셀의 둘레는 초기 4이지만, 인접한 셀이 땅인 경우 둘레가 겹치기 때문에 2씩 감소시킵니다.


```
return perimeter;
```
최종적으로 계산된 perimeter 값을 반환합니다.
