### PR TITLE
[674] Longest Continuous Increasing Subsequence

### DIFF
--- a/dlek-user/[674] Longest Continuous Increasing Subsequence
+++ b/dlek-user/[674] Longest Continuous Increasing Subsequence
@@ -1,0 +1,20 @@
+class Solution(object):
+    def findLengthOfLCIS(self, nums):
+        """
+        :type nums: List[int]
+        :rtype: int
+        """
+        if not nums:
+            return 0
+        
+        current_length = 1
+        max_length = 1
+        
+        for i in range(1, len(nums)):
+            if nums[i] > nums[i - 1]:
+                current_length += 1
+                max_length = max(max_length, current_length)
+            else:
+                current_length = 1
+        
+        return max_length


### PR DESCRIPTION

# [674] Longest Continuous Increasing Subsequence

## 문제 설명 

Given an unsorted array of integers `nums`, return _the length of the longest **continuous increasing subsequence** (i.e. subarray)_. The subsequence must be **strictly** increasing.

A **continuous increasing subsequence** is defined by two indices `l` and `r` (`l < r`) such that it is `[nums[l], nums[l + 1], ..., nums[r - 1], nums[r]]` and for each `l <= i < r`, `nums[i] < nums[i + 1]`.

 

#### Example 1:

> Input: nums = [1,3,5,4,7]
> Output: 3
> Explanation: The longest continuous increasing subsequence is [1,3,5] with length 3.
> Even though [1,3,5,7] is an increasing subsequence, it is not continuous as elements 5 and 7 are separated by element
> 4.

#### Example 2:

> Input: nums = [2,2,2,2,2]
> Output: 1
> Explanation: The longest continuous increasing subsequence is [2] with length 1. Note that it must be strictly
> increasing.
> 

## 코드 설명

```
class Solution(object):
    def findLengthOfLCIS(self, nums):
        """
        :type nums: List[int]
        :rtype: int
        """
        if not nums:
            return 0

        current_length = 1
        max_length = 1

        for i in range(1, len(nums)):
            if nums[i] > nums[i - 1]:
                current_length += 1
                max_length = max(max_length, current_length)
            else:
                current_length = 1

        return max_length
```
#
```
if not nums:
    return 0
```
입력 배열 nums가 비어 있는 경우, 바로 0을 반환합니다.


```
current_length = 1
```
current_length는 현재 연속적으로 증가하는 부분 수열의 길이를 저장하는 변수로 초기값을 1로 설정합니다.


```
max_length = 1
```
max_length는 가장 긴 연속 증가 부분 수열의 길이를 저장하며 초기값을 1로 설정합니다.


```
for i in range(1, len(nums)):
```
배열 nums를 두 번째 요소부터 순회하면서, 이전 요소와 현재 요소를 비교합니다.


```
if nums[i] > nums[i - 1]:
    current_length += 1
    max_length = max(max_length, current_length)
```
만약 nums[i] > nums[i-1]이면, 연속 증가하는 부분 수열이므로 current_length를 1씩 증가시키고, max_length도 갱신합니다.


```
else:
    current_length = 1
```
그렇지 않으면, 연속적인 증가가 끊긴 것이므로 current_length를 1로 다시 초기화합니다.


```
return max_length
```
가장 긴 연속 증가 부분 수열의 길이인 max_length를 반환합니다.