### PR TITLE
[696] Count Binary Substrings

### DIFF
--- a/dlek-user/[696] Count Binary Substrings
+++ b/dlek-user/[696] Count Binary Substrings
@@ -1,0 +1,19 @@
+class Solution(object):
+    def countBinarySubstrings(self, s):
+
+        groups = []
+        count = 1
+        
+        for i in range(1, len(s)):
+            if s[i] == s[i - 1]:
+                count += 1
+            else:
+                groups.append(count)
+                count = 1
+        groups.append(count)
+        
+        result = 0
+        for i in range(1, len(groups)):
+            result += min(groups[i - 1], groups[i])
+        
+        return result


### PR DESCRIPTION

# [696] Count Binary Substrings

## 문제 설명 

Given a binary string `s`, return the number of non-empty substrings that have the same number of `0`'s and `1`'s, and all the `0`'s and all the `1`'s in these substrings are grouped consecutively.

Substrings that occur multiple times are counted the number of times they occur.

 

#### Example 1:

> Input: s = "00110011"
> Output: 6
> Explanation: There are 6 substrings that have equal number of consecutive 1's and 0's: "0011", "01", "1100", "10", "0011", and "01".
> Notice that some of these substrings repeat and are counted the number of times they occur.
> Also, "00110011" is not a valid substring because all the 0's (and 1's) are not grouped together.

#### Example 2:

Input: s = "10101"
Output: 4
Explanation: There are 4 substrings: "10", "01", "10", "01" that have equal number of consecutive 1's and 0's.

## 코드 설명

```
class Solution(object):
    def countBinarySubstrings(self, s):

        groups = []
        count = 1

        for i in range(1, len(s)):
            if s[i] == s[i - 1]:
                count += 1
            else:
                groups.append(count)
                count = 1
        groups.append(count)

        result = 0
        for i in range(1, len(groups)):
            result += min(groups[i - 1], groups[i])

        return result
```
#
```
groups = []
count = 1
```
연속된 0과 1의 그룹 길이를 저장합니다.

```
for i in range(1, len(s)):
    if s[i] == s[i - 1]:
        count += 1
    else:
        groups.append(count)
        count = 1
groups.append(count)
```
주어진 문자열 s를 순회하며 연속된 0 또는 1의 개수를 계산합니다. 같은 문자가 계속 나오면 count를 증가시키고, 다른 문자가 나오면 count 값을 groups 리스트에 저장한 후, count를 1로 초기화합니다.
마지막 그룹도 groups에 추가해야 하므로, 반복이 끝난 후 마지막에 groups.append(count)를 추가합니다.

```
result = 0
for i in range(1, len(groups)):
    result += min(groups[i - 1], groups[i])
```
그룹들의 길이가 저장된 리스트 groups에서 인접한 두 그룹(이전 그룹과 현재 그룹)의 최소 길이만큼 부분 문자열이 생성될 수 있습니다. 이는 최소한의 그룹 길이만큼 0과 1이 번갈아 나타날 수 있기 때문입니다.
예를 들어 "000111"에서는 0과 1의 그룹 길이가 모두 3이므로, 가능한 부분 문자열은 "01", "0011", "000111"로 총 3개입니다.

```
return result
```
각 인접한 그룹 쌍마다 가능한 부분 문자열 개수를 모두 더한 후 그 값을 반환합니다.
