### PR TITLE
[724] Find Pivot Index

### DIFF
--- a/dlek-user/[724] Find Pivot Index
+++ b/dlek-user/[724] Find Pivot Index
@@ -1,0 +1,18 @@
+class Solution {
+    public int pivotIndex(int[] nums) {
+        int totalSum = 0;
+        for (int num : nums) {
+            totalSum += num;
+        }
+        
+        int leftSum = 0;
+        for (int i = 0; i < nums.length; i++) {
+            if (leftSum == totalSum - leftSum - nums[i]) {
+                return i;
+            }
+            leftSum += nums[i];
+        }
+        
+        return -1;
+    }
+}


### PR DESCRIPTION

# [724] Find Pivot Index

## 문제 설명 

Given an array of integers `nums`, calculate the **pivot index** of this array.

The **pivot index** is the index where the sum of all the numbers **strictly** to the left of the index is equal to the sum of all the numbers **strictly** to the index's right.

If the index is on the left edge of the array, then the left sum is `0` because there are no elements to the left. This also applies to the right edge of the array.

Return the **leftmost pivot index**. If no such index exists, return `-1`.

 

#### Example 1:

> Input: nums = [1,7,3,6,5,6]
> Output: 3
> Explanation:
> The pivot index is 3.
> Left sum = nums[0] + nums[1] + nums[2] = 1 + 7 + 3 = 11
> Right sum = nums[4] + nums[5] = 5 + 6 = 11

#### Example 2:

> Input: nums = [1,2,3]
> Output: -1
> Explanation:
> There is no index that satisfies the conditions in the problem statement.

#### Example 3:

> Input: nums = [2,1,-1]
> Output: 0
> Explanation:
> The pivot index is 0.
> Left sum = 0 (no elements to the left of index 0)
> Right sum = nums[1] + nums[2] = 1 + -1 = 0

## 코드 설명

```
class Solution {
    public int pivotIndex(int[] nums) {
        int totalSum = 0;
        for (int num : nums) {
            totalSum += num;
        }

        int leftSum = 0;
        for (int i = 0; i < nums.length; i++) {
            if (leftSum == totalSum - leftSum - nums[i]) {
                return i;
            }
            leftSum += nums[i];
        }

        return -1;
    }
}
```
#
```
int totalSum = 0;
for (int num : nums) {
    totalSum += num;
}
```
배열의 모든 요소의 합을 totalSum에 저장합니다.

```
int leftSum = 0;
```
배열을 순차적으로 탐색하며 왼쪽 합을 leftSum에 누적합니다.

```
for (int i = 0; i < nums.length; i++) {
    if (leftSum == totalSum - leftSum - nums[i]) {
        return i;
    }
    leftSum += nums[i];
}
```
현재 인덱스에서의 오른쪽 합은 totalSum - leftSum - nums[i]로 구할 수 있습니다. 이 값이 왼쪽 합과 같으면 해당 인덱스를 피벗으로 반환합니다.

```
return -1;
```
배열 끝까지 탐색했지만 피벗 인덱스를 찾지 못하면 -1을 반환합니다.
