### PR TITLE
[762] Prime Number of Set Bits in Binary Representation

### DIFF
--- a/dlek-user/[762] Prime Number of Set Bits in Binary Representation
+++ b/dlek-user/[762] Prime Number of Set Bits in Binary Representation
@@ -1,0 +1,18 @@
+class Solution {
+
+    private static final Set<Integer> primes = new HashSet<>(Arrays.asList(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31));
+
+    public int countPrimeSetBits(int left, int right) {
+        int count = 0;
+        
+        for (int num = left; num <= right; num++) {
+            int setBits = Integer.bitCount(num);
+            
+            if (primes.contains(setBits)) {
+                count++;
+            }
+        }
+        
+        return count;
+    }
+}


### PR DESCRIPTION

# [762] Prime Number of Set Bits in Binary Representation

## 문제 설명 

Given two integers `left` and `right`, return _the **count** of numbers in the inclusive range_ `[left, right]` _having a **prime number of set bits** in their binary representation_.

Recall that the **number of set bits** an integer has is the number of `1`'s present when written in binary.

- For example, `21` written in binary is `10101`, which has `3` set bits.

 

#### Example 1:

> Input: left = 6, right = 10
> Output: 4
> Explanation:
> 6  -> 110 (2 set bits, 2 is prime)
> 7  -> 111 (3 set bits, 3 is prime)
> 8  -> 1000 (1 set bit, 1 is not prime)
> 9  -> 1001 (2 set bits, 2 is prime)
> 10 -> 1010 (2 set bits, 2 is prime)
> 4 numbers have a prime number of set bits.

#### Example 2:

> Input: left = 10, right = 15
> Output: 5
> Explanation:
> 10 -> 1010 (2 set bits, 2 is prime)
> 11 -> 1011 (3 set bits, 3 is prime)
> 12 -> 1100 (2 set bits, 2 is prime)
> 13 -> 1101 (3 set bits, 3 is prime)
> 14 -> 1110 (3 set bits, 3 is prime)
> 15 -> 1111 (4 set bits, 4 is not prime)
> 5 numbers have a prime number of set bits.

## 코드 설명

```
class Solution {

    private static final Set<Integer> primes = new HashSet<>(Arrays.asList(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31));

    public int countPrimeSetBits(int left, int right) {
        int count = 0;

        for (int num = left; num <= right; num++) {
            int setBits = Integer.bitCount(num);

            if (primes.contains(setBits)) {
                count++;
            }
        }

        return count;
    }
}
```
#
```
private static final Set<Integer> primes = new HashSet<>(Arrays.asList(2, 3, 5, 7, 11, 13, 17, 19, 23, 29, 31));
```
primes는 1의 개수가 될 수 있는 최대 범위 안에서의 소수를 저장한 집합입니다. (최대 범위는 32비트 이내의 수이므로 31까지의 소수만 고려하면 됩니다.)


```
for (int num = left; num <= right; num++) {
    int setBits = Integer.bitCount(num);
```
주어진 left부터 right까지의 범위에서 각 숫자의 이진수에서 1의 개수를 계산하기 위해 Integer.bitCount() 메서드를 사용합니다.


```
if (primes.contains(setBits)) {
    count++;
```
1의 개수가 primes 집합에 포함되어 있는지 확인하여, 포함되면 카운트를 증가시킵니다.




