### PR TITLE
[836] Rectangle Overlap

### DIFF
--- a/dlek-user/[836] Rectangle Overlap
+++ b/dlek-user/[836] Rectangle Overlap
@@ -1,0 +1,11 @@
+class Solution {
+    public boolean isRectangleOverlap(int[] rec1, int[] rec2) {
+        if (rec1[2] <= rec2[0] ||
+            rec1[0] >= rec2[2] ||
+            rec1[3] <= rec2[1] ||
+            rec1[1] >= rec2[3]) {
+            return false;
+        }
+        return true;
+    }
+}


### PR DESCRIPTION

# [836] Rectangle Overlap

## 문제 설명 

An axis-aligned rectangle is represented as a list `[x1, y1, x2, y2]`, where `(x1, y1)` is the coordinate of its bottom-left corner, and `(x2, y2)` is the coordinate of its top-right corner. Its top and bottom edges are parallel to the X-axis, and its left and right edges are parallel to the Y-axis.

Two rectangles overlap if the area of their intersection is **positive**. To be clear, two rectangles that only touch at the corner or edges do not overlap.

Given two axis-aligned rectangles `rec1` and `rec2`, return `true` if they overlap, otherwise return `false`.

 

#### Example 1:

> Input: rec1 = [0,0,2,2], rec2 = [1,1,3,3]
> Output: true

#### Example 2:

> Input: rec1 = [0,0,1,1], rec2 = [1,0,2,1]
> Output: false

#### Example 3:

> Input: rec1 = [0,0,1,1], rec2 = [2,2,3,3]
> Output: false

## 코드 설명

```
class Solution {
    public boolean isRectangleOverlap(int[] rec1, int[] rec2) {
        if (rec1[2] <= rec2[0] ||
            rec1[0] >= rec2[2] ||
            rec1[3] <= rec2[1] ||
            rec1[1] >= rec2[3]) {
            return false;
        }
        return true;
    }
}
```
#
```
if (rec1[2] <= rec2[0] ||
```
rec1의 오른쪽 경계가 rec2의 왼쪽 경계보다 작거나 같으면 rec1이 rec2의 왼쪽에 있습니다.

```
rec1[0] >= rec2[2] ||
```
rec1의 왼쪽 경계가 rec2의 오른쪽 경계보다 크거나 같으면 rec1이 rec2의 오른쪽에 있습니다.

```
rec1[3] <= rec2[1] ||
```
rec1의 위쪽 경계가 rec2의 아래쪽 경계보다 작거나 같으면 rec1이 rec2의 아래에 있습니다.

```
rec1[1] >= rec2[3]) {
```
rec1의 아래쪽 경계가 rec2의 위쪽 경계보다 크거나 같으면 rec1이 rec2의 위에 있습니다.

```
return false;
```
이 네 가지 조건 중 하나라도 성립하면, 두 직사각형은 겹치지 않습니다.

