### PR TITLE
[938] Range Sum of BST

### DIFF
--- a/dlek-user/[938] Range Sum of BST
+++ b/dlek-user/[938] Range Sum of BST
@@ -1,0 +1,30 @@
+/**
+ * Definition for a binary tree node.
+ * public class TreeNode {
+ *     int val;
+ *     TreeNode left;
+ *     TreeNode right;
+ *     TreeNode() {}
+ *     TreeNode(int val) { this.val = val; }
+ *     TreeNode(int val, TreeNode left, TreeNode right) {
+ *         this.val = val;
+ *         this.left = left;
+ *         this.right = right;
+ *     }
+ * }
+ */
+class Solution {
+    public int rangeSumBST(TreeNode root, int low, int high) {
+        if (root == null) return 0;
+
+        if (root.val < low) {
+            return rangeSumBST(root.right, low, high);
+        }
+        
+        if (root.val > high) {
+            return rangeSumBST(root.left, low, high);
+        }
+        
+        return root.val + rangeSumBST(root.left, low, high) + rangeSumBST(root.right, low, high);
+    }
+}


### PR DESCRIPTION

# [938] Range Sum of BST

## 문제 설명 

Given the `root` node of a binary search tree and two integers `low` and `high`, return _the sum of values of all nodes with a value in the **inclusive** range_ `[low, high]`.

 

#### Example 1:


> Input: root = [10,5,15,3,7,null,18], low = 7, high = 15
> Output: 32
> Explanation: Nodes 7, 10, and 15 are in the range [7, 15]. 7 + 10 + 15 = 32.

#### Example 2:


> Input: root = [10,5,15,3,7,13,18,1,null,6], low = 6, high = 10
> Output: 23
> Explanation: Nodes 6, 7, and 10 are in the range [6, 10]. 6 + 7 + 10 = 23.

## 코드 설명

```
class Solution {
    public int rangeSumBST(TreeNode root, int low, int high) {
        if (root == null) return 0;

        if (root.val < low) {
            return rangeSumBST(root.right, low, high);
        }

        if (root.val > high) {
            return rangeSumBST(root.left, low, high);
        }

        return root.val + rangeSumBST(root.left, low, high) + rangeSumBST(root.right, low, high);
    }
}
```
#
```
if (root == null) return 0;
```
root == null이면 리프 노드까지 탐색했음을 의미하므로 0을 반환합니다.


```
if (root.val < low) {
    return rangeSumBST(root.right, low, high);
}
```
root.val < low일 경우 왼쪽 노드는 모두 범위 밖이므로 오른쪽 자식 노드만 탐색합니다.



```
if (root.val > high) {
    return rangeSumBST(root.left, low, high);
}
```
root.val > high일 경우 오른쪽 노드는 모두 범위 밖이므로 왼쪽 자식 노드만 탐색합니다.



```
return root.val + rangeSumBST(root.left, low, high) + rangeSumBST(root.right, low, high);
```
low <= root.val <= high인 경우 현재 노드의 값을 더하고 왼쪽 및 오른쪽 자식 노드를 재귀적으로 탐색하여 범위 내의 값을 더합니다.


