### PR TITLE
[1018] Binary Prefix Divisible By 5

### DIFF
--- a/dlek-user/[1018] Binary Prefix Divisible By 5
+++ b/dlek-user/[1018] Binary Prefix Divisible By 5
@@ -1,0 +1,14 @@
+class Solution {
+    public List<Boolean> prefixesDivBy5(int[] nums) {
+        List<Boolean> result = new ArrayList<>();
+        int current = 0;
+        
+        for (int i = 0; i < nums.length; i++) {
+            current = (current << 1) | nums[i];
+            current %= 5;
+            result.add(current == 0);
+        }
+        
+        return result;
+    }
+}


### PR DESCRIPTION

# [1018] Binary Prefix Divisible By 5

## 문제 설명 

You are given a binary array `nums` **(0-indexed).**

We define `xi` as the number whose binary representation is the subarray `nums[0..i]` (from most-significant-bit to least-significant-bit).

- For example, if `nums = [1,0,1]`, then `x0 = 1`, `x1 = 2`, and `x2 = 5`.

Return _an array of booleans_ `answer` _where_ `answer[i]` _is_ `true` _if_ `xi` _is divisible by_ `5`.

 

#### Example 1:

> Input: nums = [0,1,1]
> Output: [true,false,false]
> Explanation: The input numbers in binary are 0, 01, 011; which are 0, 1, and 3 in base-10.
> Only the first number is divisible by 5, so answer[0] is true.

#### Example 2:

> Input: nums = [1,1,1]
> Output: [false,false,false]

## 코드 설명

```
class Solution {
    public List<Boolean> prefixesDivBy5(int[] nums) {
        List<Boolean> result = new ArrayList<>();
        int current = 0;

        for (int i = 0; i < nums.length; i++) {
            current = (current << 1) | nums[i];
            current %= 5;
            result.add(current == 0);
        }

        return result;
    }
}
```
#
```
current = (current << 1) | nums[i];
```
current는 nums[0..i] 범위의 이진수 값입니다. 이진수는 비트 시프트 연산(<< 1)을 통해 왼쪽으로 이동하고, nums[i] 값(0 또는 1)을 추가하는 방식으로 갱신됩니다.


```
current %= 5;
```
현재 계산된 current 값이 너무 커질 수 있기 때문에, 5로 나눈 나머지를 사용하여 필요한 값만 계산합니다. 이 과정은 current가 커지는 것을 방지하고, 5로 나누어지는지 체크하기 위해 중요합니다.



```
result.add(current == 0);
```
5로 나누어 떨어지면 current == 0이므로 true를, 그렇지 않으면 false를 리스트에 추가합니다.



```
return result;
```
이 결과는 각 인덱스에서 그 인덱스까지의 이진수가 5로 나누어지는지를 나타내는 Boolean 값들의 리스트입니다.

