### PR TITLE
[1108] Defanging an IP Address

### DIFF
--- a/dlek-user/[1108] Defanging an IP Address
+++ b/dlek-user/[1108] Defanging an IP Address
@@ -1,0 +1,5 @@
+class Solution {
+    public String defangIPaddr(String address) {
+        return address.replace(".", "[.]");
+    }
+}


### PR DESCRIPTION

# [1108] Defanging an IP Address

## 문제 설명 

Given a valid (IPv4) IP `address`, return a defanged version of that IP address.

A _defanged IP address_ replaces every period `"."` with `"[.]"`.

 

#### Example 1:

> Input: address = "1.1.1.1"
> Output: "1[.]1[.]1[.]1"

#### Example 2:

> Input: address = "255.100.50.0"
> Output: "255[.]100[.]50[.]0"

## 코드 설명

```
class Solution {
    public String defangIPaddr(String address) {
        return address.replace(".", "[.]");
    }
}
```
#
```
return address.replace(".", "[.]");
```
replace 메서드를 사용하여 IPv4 주소 문자열에 있는 모든 점(.)을 [.]로 대체합니다.

