### PR TITLE
[1128] Number of Equivalent Domino Pairs

### DIFF
--- a/dlek-user/[1128] Number of Equivalent Domino Pairs
+++ b/dlek-user/[1128] Number of Equivalent Domino Pairs
@@ -1,0 +1,16 @@
+class Solution {
+    public int numEquivDominoPairs(int[][] dominoes) {
+        Map<Integer, Integer> countMap = new HashMap<>();
+        int pairs = 0;
+
+        for (int[] domino : dominoes) {
+            int key = Math.min(domino[0], domino[1]) * 10 + Math.max(domino[0], domino[1]);
+
+            pairs += countMap.getOrDefault(key, 0);
+
+            countMap.put(key, countMap.getOrDefault(key, 0) + 1);
+        }
+
+        return pairs;
+    }
+}


### PR DESCRIPTION

# [1128] Number of Equivalent Domino Pairs

## 문제 설명 

Given a list of `dominoes`, `dominoes[i] = [a, b]` is equivalent to `dominoes[j] = [c, d]` if and only if either (`a == c` and `b == d`), or (`a == d` and `b == c`) - that is, one domino can be rotated to be equal to another domino.

Return _the number of pairs_ `(i, j)` _for which_ `0 <= i < j < dominoes.length`, _and_ `dominoes[i]` _is **equivalent to**_ `dominoes[j]`.

 

#### Example 1:

> Input: dominoes = [[1,2],[2,1],[3,4],[5,6]]
> Output: 1

#### Example 2:

> Input: dominoes = [[1,2],[1,2],[1,1],[1,2],[2,2]]
> Output: 3

## 코드 설명

```
class Solution {
    public int numEquivDominoPairs(int[][] dominoes) {
        Map<Integer, Integer> countMap = new HashMap<>();
        int pairs = 0;

        for (int[] domino : dominoes) {
            int key = Math.min(domino[0], domino[1]) * 10 + Math.max(domino[0], domino[1]);

            pairs += countMap.getOrDefault(key, 0);

            countMap.put(key, countMap.getOrDefault(key, 0) + 1);
        }

        return pairs;
    }
}
```
#
```
 int key = Math.min(domino[0], domino[1]) * 10 + Math.max(domino[0], domino[1]);
```
각 도미노 [a, b]는 항상 작은 값이 앞에 오도록 키로 변환합니다.
이 방식으로 [1, 2]와 [2, 1]은 동일한 키(12)를 갖습니다.

```
Map<Integer, Integer> countMap = new HashMap<>();
int pairs = 0;
```
countMap은 각 도미노 키의 빈도를 저장합니다.
도미노를 처리할 때마다 현재 키의 빈도를 기반으로 쌍의 개수를 계산하고, 빈도를 업데이트합니다.



```
pairs += countMap.getOrDefault(key, 0);
```
이미 등장한 동일한 도미노 키의 개수(countMap.getOrDefault(key, 0))를 pairs에 더합니다.



```
countMap.put(key, countMap.getOrDefault(key, 0) + 1);
```
현재 도미노 키의 빈도를 1 증가시킵니다.

