### PR TITLE
[1217] Minimum Cost to Move Chips to The Same Position

### DIFF
--- a/dlek-user/[1217] Minimum Cost to Move Chips to The Same Position
+++ b/dlek-user/[1217] Minimum Cost to Move Chips to The Same Position
@@ -1,0 +1,16 @@
+class Solution {
+    public int minCostToMoveChips(int[] position) {
+        int evenCount = 0;
+        int oddCount = 0;
+
+        for (int pos : position) {
+            if (pos % 2 == 0) {
+                evenCount++;
+            } else {
+                oddCount++;
+            }
+        }
+
+        return Math.min(evenCount, oddCount);
+    }
+}


### PR DESCRIPTION

# [1217] Minimum Cost to Move Chips to The Same Position

## 문제 설명 

We have `n` chips, where the position of the `ith` chip is `position[i]`.

We need to move all the chips to **the same position**. In one step, we can change the position of the `ith` chip from `position[i]` to:

- `position[i] + 2` or `position[i] - 2` with `cost = 0`.
- `position[i] + 1` or `position[i] - 1` with `cost = 1`.

Return _the minimum cost_ needed to move all the chips to the same position.

 

#### Example 1:


> Input: position = [1,2,3]
> Output: 1
> Explanation: First step: Move the chip at position 3 to position 1 with cost = 0.
> Second step: Move the chip at position 2 to position 1 with cost = 1.
> Total cost is 1.

#### Example 2:


> Input: position = [2,2,2,3,3]
> Output: 2
> Explanation: We can move the two chips at position  3 to position 2. Each move has cost = 1. The total cost = 2.

#### Example 3:

> Input: position = [1,1000000000]
> Output: 1

## 코드 설명

```
class Solution {
    public int minCostToMoveChips(int[] position) {
        int evenCount = 0;
        int oddCount = 0;

        for (int pos : position) {
            if (pos % 2 == 0) {
                evenCount++;
            } else {
                oddCount++;
            }
        }

        return Math.min(evenCount, oddCount);
    }
}
```
#
```
for (int pos : position) {
    if (pos % 2 == 0) {
        evenCount++;
    } else {
        oddCount++;
    }
}
```
배열 position을 순회하며 짝수 위치 칩과 홀수 위치 칩의 개수를 각각 계산합니다.


```
return Math.min(evenCount, oddCount);
```
칩을 모두 짝수 위치로 이동하는 비용은 oddCount입니다.
칩을 모두 홀수 위치로 이동하는 비용은 evenCount입니다.
두 비용 중 작은 값을 반환합니다.

