### PR TITLE
[1313] Decompress Run-Length Encoded List

### DIFF
--- a/dlek-user/[1313] Decompress Run-Length Encoded List
+++ b/dlek-user/[1313] Decompress Run-Length Encoded List
@@ -1,0 +1,21 @@
+class Solution {
+    public int[] decompressRLElist(int[] nums) {
+        List<Integer> decompressed = new ArrayList<>();
+
+        for (int i = 0; i < nums.length; i += 2) {
+            int freq = nums[i];
+            int val = nums[i + 1];
+
+            for (int j = 0; j < freq; j++) {
+                decompressed.add(val);
+            }
+        }
+
+        int[] result = new int[decompressed.size()];
+        for (int i = 0; i < decompressed.size(); i++) {
+            result[i] = decompressed.get(i);
+        }
+
+        return result;
+    }
+}


### PR DESCRIPTION

# [1313] Decompress Run-Length Encoded List

## 문제 설명 

We are given a list `nums` of integers representing a list compressed with run-length encoding.

Consider each adjacent pair of elements `[freq, val] = [nums[2*i], nums[2*i+1]]` (with `i >= 0`).  For each such pair, there are `freq` elements with value `val` concatenated in a sublist. Concatenate all the sublists from left to right to generate the decompressed list.

Return the decompressed list.

 

#### Example 1:

> Input: nums = [1,2,3,4]
> Output: [2,4,4,4]
> Explanation: The first pair [1,2] means we have freq = 1 and val = 2 so we generate the array [2].
> The second pair [3,4] means we have freq = 3 and val = 4 so we generate [4,4,4].
> At the end the concatenation [2] + [4,4,4] is [2,4,4,4].

#### Example 2:

> Input: nums = [1,1,2,3]
> Output: [1,3,3]

## 코드 설명

```
class Solution {
    public int[] decompressRLElist(int[] nums) {
        List<Integer> decompressed = new ArrayList<>();

        for (int i = 0; i < nums.length; i += 2) {
            int freq = nums[i];
            int val = nums[i + 1];

            for (int j = 0; j < freq; j++) {
                decompressed.add(val);
            }
        }

        int[] result = new int[decompressed.size()];
        for (int i = 0; i < decompressed.size(); i++) {
            result[i] = decompressed.get(i);
        }

        return result;
    }
}
```
#
```
List<Integer> decompressed = new ArrayList<>();
```
결과를 저장할 ArrayList를 생성합니다.


```
for (int i = 0; i < nums.length; i += 2) {
    int freq = nums[i];
    int val = nums[i + 1];
```
nums의 길이만큼 2씩 증가하며 각 [freq,val] 쌍을 처리합니다.



```
for (int j = 0; j < freq; j++) {
    decompressed.add(val);
}
```
내부 반복문으로 freq만큼 val을 추가합니다.



```
int[] result = new int[decompressed.size()];
for (int i = 0; i < decompressed.size(); i++) {
    result[i] = decompressed.get(i);
}

return result;
```
결과 ArrayList를 정수 배열로 변환하여 반환합니다.

