### PR TITLE
[1399] Count Largest Group

### DIFF
--- a/dlek-user/[1399] Count Largest Group
+++ b/dlek-user/[1399] Count Largest Group
@@ -1,0 +1,30 @@
+class Solution {
+    public int countLargestGroup(int n) {
+        HashMap<Integer, Integer> groupCount = new HashMap<>();
+        int maxGroupSize = 0;
+
+        for (int i = 1; i <= n; i++) {
+            int digitSum = getDigitSum(i);
+            groupCount.put(digitSum, groupCount.getOrDefault(digitSum, 0) + 1);
+            maxGroupSize = Math.max(maxGroupSize, groupCount.get(digitSum));
+        }
+
+        int largestGroupCount = 0;
+        for (int size : groupCount.values()) {
+            if (size == maxGroupSize) {
+                largestGroupCount++;
+            }
+        }
+
+        return largestGroupCount;
+    }
+
+    private int getDigitSum(int num) {
+        int sum = 0;
+        while (num > 0) {
+            sum += num % 10;
+            num /= 10;
+        }
+        return sum;
+    }
+}


### PR DESCRIPTION

# [1399] Count Largest Group

## 문제 설명 

You are given an integer `n`.

Each number from `1` to `n` is grouped according to the sum of its digits.

Return _the number of groups that have the largest size_.

 

#### Example 1:

> Input: n = 13
> Output: 4
> Explanation: There are 9 groups in total, they are grouped according sum of its digits of numbers from 1 to 13:
> [1,10], [2,11], [3,12], [4,13], [5], [6], [7], [8], [9].
> There are 4 groups with largest size.

#### Example 2:

> Input: n = 2
> Output: 2
> Explanation: There are 2 groups [1], [2] of size 1.

## 코드 설명

```
class Solution {
    public int countLargestGroup(int n) {
        HashMap<Integer, Integer> groupCount = new HashMap<>();
        int maxGroupSize = 0;

        for (int i = 1; i <= n; i++) {
            int digitSum = getDigitSum(i);
            groupCount.put(digitSum, groupCount.getOrDefault(digitSum, 0) + 1);
            maxGroupSize = Math.max(maxGroupSize, groupCount.get(digitSum));
        }

        int largestGroupCount = 0;
        for (int size : groupCount.values()) {
            if (size == maxGroupSize) {
                largestGroupCount++;
            }
        }

        return largestGroupCount;
    }

    private int getDigitSum(int num) {
        int sum = 0;
        while (num > 0) {
            sum += num % 10;
            num /= 10;
        }
        return sum;
    }
}
```
#
```
int sum = 0;
while (num > 0) {
    sum += num % 10;
    num /= 10;
}
return sum;
```
주어진 숫자 num의 각 자리수를 더해서 반환합니다.


```
HashMap<Integer, Integer> groupCount = new HashMap<>();
```
HashMap<Integer, Integer>를 사용해, 각 자리수 합(digit sum)에 대해 해당 합으로 그룹화된 숫자의 개수를 저장합니다.



```
for (int i = 1; i <= n; i++) {
    int digitSum = getDigitSum(i); // 자리수 합 계산
    groupCount.put(digitSum, groupCount.getOrDefault(digitSum, 0) + 1);
    maxGroupSize = Math.max(maxGroupSize, groupCount.get(digitSum)); // 최대 그룹 크기 업데이트
}
```
groupCount.getOrDefault(digitSum, 0)를 사용해 새로운 키를 초기화하거나 기존 값을 업데이트합니다.



```
int largestGroupCount = 0;
for (int size : groupCount.values()) {
    if (size == maxGroupSize) {
        largestGroupCount++;
    }
}
return largestGroupCount;
```
숫자를 순회하며 각 digitSum의 개수를 확인하고, 최대 그룹 크기를 업데이트합니다.
모든 그룹의 크기를 확인하면서 최대 크기를 가진 그룹의 개수를 셉니다.

