### PR TITLE
[1539] Kth Missing Positive Number

### DIFF
--- a/dlek-user/[1539] Kth Missing Positive Number
+++ b/dlek-user/[1539] Kth Missing Positive Number
@@ -1,0 +1,17 @@
+class Solution {
+    public int findKthPositive(int[] arr, int k) {
+        int missingCount = 0, current = 1, index = 0;
+
+        while (missingCount < k) {
+            if (index < arr.length && arr[index] == current) {
+                index++;
+            } else {
+                missingCount++;
+                if (missingCount == k) return current;
+            }
+            current++;
+        }
+
+        return -1;
+    }
+}


### PR DESCRIPTION

# ex) [1] Two Sum

## 문제 설명 

Given an array `arr` of positive integers sorted in a **strictly increasing order**, and an integer `k`.

Return _the_ `kth` _**positive** integer that is **missing** from this array_.

 

#### Example 1:

> Input: arr = [2,3,4,7,11], k = 5
> Output: 9
> Explanation: The missing positive integers are [1,5,6,8,9,10,12,13,...]. The 5th missing positive integer is 9.

#### Example 2:

> Input: arr = [1,2,3,4], k = 2
> Output: 6
> Explanation: The missing positive integers are [5,6,7,...]. The 2nd missing positive integer is 6.
> 

## 코드 설명

```
class Solution {
    public int findKthPositive(int[] arr, int k) {
        int missingCount = 0, current = 1, index = 0;

        while (missingCount < k) {
            if (index < arr.length && arr[index] == current) {
                index++;
            } else {
                missingCount++;
                if (missingCount == k) return current;
            }
            current++;
        }

        return -1;
    }
}
```
#
```
int missingCount = 0, current = 1, index = 0;
 while (missingCount < k) {
    if (index < arr.length && arr[index] == current) {
        index++;
    }
```
current 값을 1부터 증가시키면서 누락된 숫자를 찾는다.
arr[index] 와 current 가 같으면 index 를 증가시킨다.

```
else {
    missingCount++;
    if (missingCount == k) return current;
}
current++;
```
다르면 missingCount++ 를 하고 k번째 누락된 숫자이면 반환한다.

