### PR TITLE
[1572] Matrix Diagonal Sum

### DIFF
--- a/dlek-user/[1572] Matrix Diagonal Sum
+++ b/dlek-user/[1572] Matrix Diagonal Sum
@@ -1,0 +1,17 @@
+class Solution {
+    public int diagonalSum(int[][] mat) {
+        int n = mat.length;
+        int sum = 0;
+
+        for (int i = 0; i < n; i++) {
+            sum += mat[i][i];
+            sum += mat[i][n - 1 - i];
+        }
+
+        if (n % 2 == 1) {
+            sum -= mat[n / 2][n / 2];
+        }
+
+        return sum;
+    }
+}


### PR DESCRIPTION

# [1572] Matrix Diagonal Sum

## 문제 설명 

Given a square matrix `mat`, return the sum of the matrix diagonals.

Only include the sum of all the elements on the primary diagonal and all the elements on the secondary diagonal that are not part of the primary diagonal.

 

#### Example 1:


> Input: mat = [[1,2,3],
>               [4,5,6],
>               [7,8,9]]
> Output: 25
> Explanation: Diagonals sum: 1 + 5 + 9 + 3 + 7 = 25
> Notice that element mat[1][1] = 5 is counted only once.

#### Example 2:

> Input: mat = [[1,1,1,1],
>               [1,1,1,1],
>               [1,1,1,1],
>               [1,1,1,1]]
> Output: 8

#### Example 3:

> Input: mat = [[5]]
> Output: 5

## 코드 설명

```
class Solution {
    public int diagonalSum(int[][] mat) {
        int n = mat.length;
        int sum = 0;

        for (int i = 0; i < n; i++) {
            sum += mat[i][i];
            sum += mat[i][n - 1 - i];
        }

        if (n % 2 == 1) {
            sum -= mat[n / 2][n / 2];
        }

        return sum;
    }
}
```
#
```
for (int i = 0; i < n; i++) {
    sum += mat[i][i];
```
Primary Diagonal (mat[i][i])은 (0,0), (1,1), (2,2), … 요소 합산




```
sum += mat[i][n - 1 - i];
```
Secondary Diagonal (mat[i][n-1-i]) : (0,n-1), (1,n-2), (2,n-3), … 요소 합산





```
if (n % 2 == 1) {
    sum -= mat[n / 2][n / 2];
}
return sum;
```
중앙 중복 요소 제거 (n % 2 == 1)
홀수 크기일 경우 중앙(mat[n/2][n/2])이 두 번 더해지므로 한 번 빼줌.

