### PR TITLE
[1588] Sum of All Odd Length Subarrays

### DIFF
--- a/dlek-user/[1588] Sum of All Odd Length Subarrays
+++ b/dlek-user/[1588] Sum of All Odd Length Subarrays
@@ -1,0 +1,16 @@
+class Solution {
+    public int sumOddLengthSubarrays(int[] arr) {
+        int sum = 0;
+        int n = arr.length;
+
+        for (int i = 0; i < n; i++) {
+            int left = i + 1;
+            int right = n - i;
+            int totalSubarrays = left * right;
+            int oddSubarrays = (totalSubarrays + 1) / 2;
+            sum += arr[i] * oddSubarrays;
+        }
+
+        return sum;
+    }
+}


### PR DESCRIPTION

# [1588] Sum of All Odd Length Subarrays

## 문제 설명 

Given an array of positive integers `arr`, return _the sum of all possible **odd-length subarrays** of_ `arr`.

A **subarray** is a contiguous subsequence of the array.

 

#### Example 1:

> Input: arr = [1,4,2,5,3]
> Output: 58
> Explanation: The odd-length subarrays of arr and their sums are:
> [1] = 1
> [4] = 4
> [2] = 2
> [5] = 5
> [3] = 3
> [1,4,2] = 7
> [4,2,5] = 11
> [2,5,3] = 10
> [1,4,2,5,3] = 15
> If we add all these together we get 1 + 4 + 2 + 5 + 3 + 7 + 11 + 10 + 15 = 58

#### Example 2:

> Input: arr = [1,2]
> Output: 3
> Explanation: There are only 2 subarrays of odd length, [1] and [2]. Their sum is 3.

#### Example 3:

> Input: arr = [10,11,12]
> Output: 66

## 코드 설명

```
class Solution {
    public int sumOddLengthSubarrays(int[] arr) {
        int sum = 0;
        int n = arr.length;

        for (int i = 0; i < n; i++) {
            int left = i + 1;
            int right = n - i;
            int totalSubarrays = left * right;
            int oddSubarrays = (totalSubarrays + 1) / 2;
            sum += arr[i] * oddSubarrays;
        }

        return sum;
    }
}
```
#
```
int sum = 0;
int n = arr.length;
```
각 arr[i]가 포함될 수 있는 모든 부분 배열의 개수를 계산.




```
for (int i = 0; i < n; i++) {
    int left = i + 1;
    int right = n - i;
    int totalSubarrays = left * right;
    int oddSubarrays = (totalSubarrays + 1) / 2;
```
홀수 길이의 부분 배열 개수만 필터링.




```
sum += arr[i] * oddSubarrays;
```
각 arr[i] 값을 곱해 최종 합을 구함.

