### PR TITLE
[96] Unique Binary Search Trees

### DIFF
--- a/dlek-user/[96] Unique Binary Search Trees
+++ b/dlek-user/[96] Unique Binary Search Trees
@@ -1,0 +1,17 @@
+class Solution {
+    public int numTrees(int n) {
+        int[] dp = new int[n + 1];
+        dp[0] = 1;
+        dp[1] = 1;
+
+        for (int nodes = 2; nodes <= n; nodes++) {
+            for (int root = 1; root <= nodes; root++) {
+                int left = dp[root - 1]; 
+                int right = dp[nodes - root];
+                dp[nodes] += left * right;
+            }
+        }
+
+        return dp[n];
+    }
+}


### PR DESCRIPTION

# [96] Unique Binary Search Trees
## 문제 설명 

Given an integer `n`, return _the number of structurally unique **BST**'s (binary search trees) which has exactly `n` nodes of unique values from `1` to `n`_.

 

#### Example 1:


> Input: n = 3
> Output: 5

#### Example 2:

> Input: n = 1
> Output: 1

## 코드 설명

```
class Solution {
    public int numTrees(int n) {
        int[] dp = new int[n + 1];
        dp[0] = 1;
        dp[1] = 1;

        for (int nodes = 2; nodes <= n; nodes++) {
            for (int root = 1; root <= nodes; root++) {
                int left = dp[root - 1]; 
                int right = dp[nodes - root];
                dp[nodes] += left * right;
            }
        }

        return dp[n];
    }
}
```
#
```
int[] dp = new int[n + 1];
```
dp[i]는 i개의 노드로 만들 수 있는 구조적으로 유일한 BST의 개수를 저장하는 배열입니다.
크기를 n+1로 하는 이유는 0개의 노드도 하나의 트리로 간주되기 때문입니다.




```
dp[0] = 1;
dp[1] = 1;
```
dp[0] = 1: 빈 트리(노드가 없는 트리)도 유효한 구조로 인정
dp[1] = 1: 한 개의 노드는 자신이 루트가 되는 하나의 구조만 가능






```
for (int nodes = 2; nodes <= n; nodes++) {
```
총 노드 개수를 2개부터 n까지 늘려가며 가능한 경우의 수를 누적해서 계산합니다.





```
for (int root = 1; root <= nodes; root++) {
    int left = dp[root - 1];
    int right = dp[nodes - root];
    dp[nodes] += left * right;
}
```
루트를 1 ~ nodes까지 순회합니다.
루트가 i일 때,
왼쪽 서브트리는 i - 1개의 노드
오른쪽 서브트리는 nodes - i개의 노드
이 두 서브트리의 경우의 수를 곱해서 dp[nodes]에 누적
