### PR TITLE
[215] Kth Largest Element in an Array

### DIFF
--- a/dlek-user/[215] Kth Largest Element in an Array
+++ b/dlek-user/[215] Kth Largest Element in an Array
@@ -1,0 +1,14 @@
+class Solution {
+    public int findKthLargest(int[] nums, int k) {
+        PriorityQueue<Integer> minHeap = new PriorityQueue<>();
+
+        for (int num : nums) {
+            minHeap.offer(num); 
+            if (minHeap.size() > k) {
+                minHeap.poll(); 
+            }
+        }
+
+        return minHeap.peek();
+    }
+}


### PR DESCRIPTION

# [215] Kth Largest Element in an Array

## 문제 설명 

Given an integer array `nums` and an integer `k`, return _the_ `kth` _largest element in the array_.

Note that it is the `kth` largest element in the sorted order, not the `kth` distinct element.

Can you solve it without sorting?

 

#### Example 1:

> Input: nums = [3,2,1,5,6,4], k = 2
> Output: 5

#### Example 2:

> Input: nums = [3,2,3,1,2,4,5,5,6], k = 4
> Output: 4

## 코드 설명

```
class Solution {
    public int findKthLargest(int[] nums, int k) {
        PriorityQueue<Integer> minHeap = new PriorityQueue<>();

        for (int num : nums) {
            minHeap.offer(num); 
            if (minHeap.size() > k) {
                minHeap.poll(); 
            }
        }

        return minHeap.peek();
    }
}
```
#
```
PriorityQueue<Integer> minHeap = new PriorityQueue<>();
```
Java의 PriorityQueue는 기본적으로 최소 힙(min heap) 구조입니다. 즉, 가장 작은 값이 먼저 나옵니다.




```
for (int num : nums)
```
nums 배열의 모든 숫자를 순회하면서




```
minHeap.offer(num);
```
숫자를 힙에 추가합니다.




```
if (minHeap.size() > k) { 
    minHeap.poll(); 
}
```
힙의 크기가 k를 초과하면, 가장 작은 값을 제거합니다. 이렇게 하면 힙에는 항상 가장 큰 k개만 남습니다.




```
return minHeap.peek();
```
힙의 가장 작은 값 = k번째로 큰 값입니다. 이유는 힙에는 가장 큰 k개가 있고, 그 중 가장 작은 값이니까요.

