### PR TITLE
[328] Odd Even Linked List

### DIFF
--- a/dlek-user/[328] Odd Even Linked List
+++ b/dlek-user/[328] Odd Even Linked List
@@ -1,0 +1,30 @@
+/**
+ * Definition for singly-linked list.
+ * public class ListNode {
+ *     int val;
+ *     ListNode next;
+ *     ListNode() {}
+ *     ListNode(int val) { this.val = val; }
+ *     ListNode(int val, ListNode next) { this.val = val; this.next = next; }
+ * }
+ */
+class Solution {
+    public ListNode oddEvenList(ListNode head) {
+        if (head == null || head.next == null) return head; 
+
+        ListNode odd = head;           
+        ListNode even = head.next;      
+        ListNode evenHead = even;     
+
+        while (even != null && even.next != null) {
+            odd.next = even.next;     
+            odd = odd.next;             
+
+            even.next = odd.next;       
+            even = even.next;           
+        }
+
+        odd.next = evenHead;            
+        return head;
+    }
+}


### PR DESCRIPTION

# [328] Odd Even Linked List

## 문제 설명 

Given the `head` of a singly linked list, group all the nodes with odd indices together followed by the nodes with even indices, and return _the reordered list_.

The **first** node is considered **odd**, and the **second** node is **even**, and so on.

Note that the relative order inside both the even and odd groups should remain as it was in the input.

You must solve the problem in `O(1)` extra space complexity and `O(n)` time complexity.

 

#### Example 1:


> Input: head = [1,2,3,4,5]
> Output: [1,3,5,2,4]

#### Example 2:


> Input: head = [2,1,3,5,6,4,7]
> Output: [2,3,6,7,1,5,4]

## 코드 설명

```
class Solution {
    public ListNode oddEvenList(ListNode head) {
        if (head == null || head.next == null) return head; 

        ListNode odd = head;           
        ListNode even = head.next;      
        ListNode evenHead = even;     

        while (even != null && even.next != null) {
            odd.next = even.next;     
            odd = odd.next;             

            even.next = odd.next;       
            even = even.next;           
        }

        odd.next = evenHead;            
        return head;
    }
}
```
#
```
if (head == null || head.next == null) return head;
```
노드가 0개나 1개면 이미 조건을 만족하므로 그대로 반환.




```
ListNode odd = head;
ListNode even = head.next;
ListNode evenHead = even;
```
odd: 홀수 위치의 현재 노드 (시작은 head)
even: 짝수 위치의 현재 노드 (시작은 head.next)
evenHead: 짝수 리스트의 첫 노드 위치 저장 → 마지막에 연결할 때 필요




```
while (even != null && even.next != null) {
```
짝수 노드와 그 다음 홀수 노드가 존재할 동안 반복




```
odd.next = even.next;
odd = odd.next;
```
홀수 노드의 다음을 다음 홀수 노드로 연결
홀수 포인터를 다음 홀수 노드로 이동




```
even.next = odd.next;
even = even.next;
```
짝수 노드의 다음을 다음 짝수 노드로 연결
짝수 포인터를 다음 짝수 노드로 이동




```
odd.next = evenHead;
```
홀수 리스트 끝에 짝수 리스트 시작을 연결




```
return head;
```
재정렬된 연결 리스트의 head 반환
