### PR TITLE
[331] Verify Preorder Serialization of a Binary Tree

### DIFF
--- a/dlek-user/[331] Verify Preorder Serialization of a Binary Tree
+++ b/dlek-user/[331] Verify Preorder Serialization of a Binary Tree
@@ -1,0 +1,17 @@
+class Solution {
+    public boolean isValidSerialization(String preorder) {
+        String[] nodes = preorder.split(",");
+        int slots = 1; 
+
+        for (String node : nodes) {
+            slots--; 
+            if (slots < 0) return false; 
+
+            if (!node.equals("#")) {
+                slots += 2;
+            }
+        }
+
+        return slots == 0;
+    }
+}


### PR DESCRIPTION

# [331] Verify Preorder Serialization of a Binary Tree

## 문제 설명 

One way to serialize a binary tree is to use **preorder traversal**. When we encounter a non-null node, we record the node's value. If it is a null node, we record using a sentinel value such as `'#'`.


For example, the above binary tree can be serialized to the string `"9,3,4,#,#,1,#,#,2,#,6,#,#"`, where `'#'` represents a null node.

Given a string of comma-separated values `preorder`, return `true` if it is a correct preorder traversal serialization of a binary tree.

It is **guaranteed** that each comma-separated value in the string must be either an integer or a character `'#'` representing null pointer.

You may assume that the input format is always valid.

- For example, it could never contain two consecutive commas, such as `"1,,3"`.

**Note**: You are not allowed to reconstruct the tree.

 

#### Example 1:

> Input: preorder = "9,3,4,#,#,1,#,#,2,#,6,#,#"
> Output: true

#### Example 2:

> Input: preorder = "1,#"
> Output: false

#### Example 3:

> Input: preorder = "9,#,#,1"
> Output: false

## 코드 설명

```
class Solution {
    public boolean isValidSerialization(String preorder) {
        String[] nodes = preorder.split(",");
        int slots = 1; 

        for (String node : nodes) {
            slots--; 
            if (slots < 0) return false; 

            if (!node.equals("#")) {
                slots += 2;
            }
        }

        return slots == 0;
    }
}
```
#
```
int slots = 1;
```
시작 슬롯 1개 (루트 자리)




```
for (String node : nodes) {
    slots--;
```
현재 노드를 배치하므로 슬롯 1개 소모




```
if (slots < 0) return false;
```
슬롯이 음수가 되면 구조 불가능




```
if (!node.equals("#")) {
    slots += 2;
}
```
숫자면 자식 슬롯 2개 추가




```
return slots == 0;
```
모든 노드 처리 후 슬롯이 0이어야 함

