### PR TITLE
[334] Increasing Triplet Subsequence

### DIFF
--- a/dlek-user/[334] Increasing Triplet Subsequence
+++ b/dlek-user/[334] Increasing Triplet Subsequence
@@ -1,0 +1,17 @@
+class Solution {
+    public boolean increasingTriplet(int[] nums) {
+        int first = Integer.MAX_VALUE;
+        int second = Integer.MAX_VALUE;
+
+        for (int num : nums) {
+            if (num <= first) {
+                first = num;  
+            } else if (num <= second) {
+                second = num; 
+            } else {
+                return true;
+            }
+        }
+        return false;
+    }
+}


### PR DESCRIPTION

# [334] Increasing Triplet Subsequence

## 문제 설명 

Given an integer array `nums`, return `true` _if there exists a triple of indices_ `(i, j, k)` _such that_ `i < j < k` _and_ `nums[i] < nums[j] < nums[k]`. If no such indices exists, return `false`.

 

#### Example 1:

> Input: nums = [1,2,3,4,5]
> Output: true
> Explanation: Any triplet where i < j < k is valid.

#### Example 2:

> Input: nums = [5,4,3,2,1]
> Output: false
> Explanation: No triplet exists.

#### Example 3:

> Input: nums = [2,1,5,0,4,6]
> Output: true
> Explanation: The triplet (3, 4, 5) is valid because nums[3] == 0 < nums[4] == 4 < nums[5] == 6.

## 코드 설명

```
class Solution {
    public boolean increasingTriplet(int[] nums) {
        int first = Integer.MAX_VALUE;
        int second = Integer.MAX_VALUE;

        for (int num : nums) {
            if (num <= first) {
                first = num;  
            } else if (num <= second) {
                second = num; 
            } else {
                return true;
            }
        }
        return false;
    }
}
```
#
```
int first = Integer.MAX_VALUE;
```
지금까지 본 값들 중 가장 작은 값 후보.
초기엔 “무한대”로 두어 어떤 값이 와도 갱신되도록.





```
int second = Integer.MAX_VALUE;
```
first보다 큰 값들 중 가장 작은 값 후보.
마찬가지로 초기엔 “무한대”로 시작.





```
for (int num : nums) {
```
배열을 한 번 순회





```
if (num <= first) { 
    first = num; 
}
```
현재 값이 first보다 작거나 같으면 first를 낮춥니다.
<=를 쓰는 이유: 같은 값이 반복될 때도 “첫 값”으로 압축해서 엄격한(<) 증가를 보장하기 위해서예요. (예: [2,2,3]에서 첫 두 개 2는 첫 요소로만 취급)





```
else if (num <= second) { 
    second = num; 
}
```
여기까지 왔다는 건 num > first.
그중에서 second를 더 줄일 수 있으면 줄입니다.
목표는 가능한 한 작은(second) 을 유지해, 뒤에서 올 세 번째 값이 넘기 쉬운 허들을 만드는 것.





```
else { 
    return true; 
}
```
이 블록에 들어오려면 num > second가 성립. 즉,
first < second < num → 증가하는 길이 3의 부분수열을 찾았으니 곧바로 true.





```
return false;
```
끝까지 못 찾으면 존재하지 않음.

