### PR TITLE
[376] Wiggle Subsequence

### DIFF
--- a/dlek-user/[376] Wiggle Subsequence
+++ b/dlek-user/[376] Wiggle Subsequence
@@ -1,0 +1,16 @@
+class Solution {
+    public int wiggleMaxLength(int[] nums) {
+        if (nums.length < 2) return nums.length;
+
+        int prevDiff = 0;
+        int count = 1; 
+        for (int i = 1; i < nums.length; i++) {
+            int diff = nums[i] - nums[i - 1];
+            if ((diff > 0 && prevDiff <= 0) || (diff < 0 && prevDiff >= 0)) {
+                count++;
+                prevDiff = diff;
+            }
+        }
+        return count;
+    }
+}


### PR DESCRIPTION

# [376] Wiggle Subsequence

## 문제 설명 

**A wiggle sequence** is a sequence where the differences between successive numbers strictly alternate between positive and negative. The first difference (if one exists) may be either positive or negative. A sequence with one element and a sequence with two non-equal elements are trivially wiggle sequences.

- For example, `[1, 7, 4, 9, 2, 5]` is a **wiggle sequence** because the differences `(6, -3, 5, -7, 3)` alternate between positive and negative.
- In contrast, `[1, 4, 7, 2, 5]` and `[1, 7, 4, 5, 5]` are not wiggle sequences. The first is not because its first two differences are positive, and the second is not because its last difference is zero.

A **subsequence** is obtained by deleting some elements (possibly zero) from the original sequence, leaving the remaining elements in their original order.

Given an integer array `nums`, return _the length of the longest **wiggle subsequence of**_ `nums`.

 

#### Example 1:

> Input: nums = [1,7,4,9,2,5]
> Output: 6
> Explanation: The entire sequence is a wiggle sequence with differences (6, -3, 5, -7, 3).

#### Example 2:

> Input: nums = [1,17,5,10,13,15,10,5,16,8]
> Output: 7
> Explanation: There are several subsequences that achieve this length.
> One is [1, 17, 10, 13, 10, 16, 8] with differences (16, -7, 3, -3, 6, -8).

#### Example 3:

> Input: nums = [1,2,3,4,5,6,7,8,9]
> Output: 2

## 코드 설명

```
class Solution {
    public int wiggleMaxLength(int[] nums) {
        if (nums.length < 2) return nums.length;

        int prevDiff = 0;
        int count = 1; 
        for (int i = 1; i < nums.length; i++) {
            int diff = nums[i] - nums[i - 1];
            if ((diff > 0 && prevDiff <= 0) || (diff < 0 && prevDiff >= 0)) {
                count++;
                prevDiff = diff;
            }
        }
        return count;
    }
}
```
#
```
if (nums.length < 2) return nums.length;
```
길이가 0 또는 1 → 그대로 리턴.




```
prevDiff = 0
```
이전 차이값(양/음 구분용).




```
count = 1
```
최소 하나는 포함.




```
diff = nums[i] - nums[i-1]
```
인접 원소 차이 계산.




```
diff > 0 && prevDiff <= 0
```
이전 차이가 음수 또는 0, 현재는 양수 → 패턴 변화




```
diff < 0 && prevDiff >= 0
```
이전 차이가 양수 또는 0, 현재는 음수 → 패턴 변화




```
count++
prevDiff = diff
```
패턴 변화 시




```
return count;
```
wiggle subsequence 최대 길이 = count.

