### PR TITLE
[386] Lexicographical Numbers

### DIFF
--- a/dlek-user/[386] Lexicographical Numbers
+++ b/dlek-user/[386] Lexicographical Numbers
@@ -1,0 +1,24 @@
+import java.util.*;
+
+class Solution {
+    public List<Integer> lexicalOrder(int n) {
+        List<Integer> result = new ArrayList<>(n);
+        int curr = 1;
+
+        for (int i = 0; i < n; i++) {
+            result.add(curr);
+
+            if (curr * 10 <= n) {          
+                curr *= 10;                 
+            } else if (curr % 10 != 9 && curr + 1 <= n) {
+                curr++;                  
+            } else {
+                while (curr % 10 == 9 || curr + 1 > n) {
+                    curr /= 10;            
+                }
+                curr++;                   
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION

# [386] Lexicographical Numbers

## 문제 설명 

Given an integer `n`, return all the numbers in the range `[1, n]` sorted in lexicographical order.

You must write an algorithm that runs in `O(n)` time and uses `O(1)` extra space. 

 

#### Example 1:

> Input: n = 13
> Output: [1,10,11,12,13,2,3,4,5,6,7,8,9]

#### Example 2:

> Input: n = 2
> Output: [1,2]

## 코드 설명

```
class Solution {
    public List<Integer> lexicalOrder(int n) {
        List<Integer> result = new ArrayList<>(n);
        int curr = 1;

        for (int i = 0; i < n; i++) {
            result.add(curr);

            if (curr * 10 <= n) {          
                curr *= 10;                 
            } else if (curr % 10 != 9 && curr + 1 <= n) {
                curr++;                  
            } else {
                while (curr % 10 == 9 || curr + 1 > n) {
                    curr /= 10;            
                }
                curr++;                   
            }
        }
        return result;
    }
}
```
#
```
List<Integer> result = new ArrayList<>(n);
```
결과를 담을 리스트를 생성합니다. 초기 용량을 n으로 잡아 성능(리사이즈)을 약간 최적화합니다.




```
int curr = 1;
```
현재 방문할 숫자를 나타내는 변수입니다.
사전순으로 1이 첫 번째이므로 curr는 1로 시작합니다.




```
for (int i = 0; i < n; i++) {
```
반드시 정확히 n개의 숫자를 순서대로 추가해야 하므로 n번 반복합니다.
반복 인덱스 i는 순서 목적으로만 사용하고 실제 값 결정은 curr로 합니다.




```
result.add(curr);
```
현재 curr를 결과에 추가합니다.
이 시점의 curr는 아직 사전순상 다음으로 출력되어야 하는 값입니다.




```
if (curr * 10 <= n) {
    curr *= 10;
} else if (curr % 10 != 9 && curr + 1 <= n) {
    curr++;
}
```
curr * 10 <= n (자식으로 내려가기)
가능하면 가장 왼쪽 자식으로 내려갑니다.
이렇게 내려가는 이유: 사전순에서 1 뒤에는 10이 오기 때문.

curr % 10 != 9 && curr + 1 <= n (같은 레벨의 다음 형제)
마지막 자리수가 9가 아니고(curr % 10 != 9), curr+1이 n을 넘지 않으면 옆 형제로 이동합니다.
curr % 10 != 9 체크는 ...9로 끝나면 같은 레벨의 다음 숫자가 사전순 규칙상 부모 레벨에서 다르게 처리되어야 해서 여기선 제외합니다.



```
else {
    while (curr % 10 == 9 || curr + 1 > n) {
        curr /= 10;
    }
    curr++;
}
```
자식으로 내려갈 수 없고, (2) 같은 레벨의 다음 형제로도 갈 수 없는 경우.

while로 부모로 올라가면서(= curr /= 10) 다음 형제가 존재할 때까지 올라갑니다.
조건 curr % 10 == 9 → 현재 끝자리가 9이면 같은 레벨의 다음 형제가 없어(예: 19 끝자리가 9이면 20은 형제가 아니라 부모의 형제에 해당), 따라서 부모로 올라가야 함.
조건 curr + 1 > n → 같은 레벨의 curr+1이 범위를 넘어서면 역시 부모로 올라가야 함(예: curr = 33, n = 34이면 33+1=34 가능이지만 curr = 34면 34+1=35 > n 이므로 올라가야 함).

while을 빠져나오면 부모에서 다음 형제로 curr++ 합니다.

이 루프는 트리에서 "다음 사전순 노드"를 찾기 위한 핵심 로직입니다.

```
return result;
```
완성된 사전순 리스트를 반환합니다.