### PR TITLE
[393] UTF-8 Validation

### DIFF
--- a/dlek-user/[393] UTF-8 Validation
+++ b/dlek-user/[393] UTF-8 Validation
@@ -1,0 +1,38 @@
+class Solution {
+    public boolean validUtf8(int[] data) {
+        int count = 0; // 현재 검사 중인 문자에서 남은 바이트 수
+
+        for (int num : data) {
+            // 하위 8비트만 사용
+            int b = num & 0xFF;
+
+            if (count == 0) {
+                // 새 문자의 첫 바이트를 만났을 때
+                if ((b >> 7) == 0b0) {
+                    // 1바이트 문자: 0xxxxxxx
+                    count = 0;
+                } else if ((b >> 5) == 0b110) {
+                    // 2바이트 문자: 110xxxxx
+                    count = 1;
+                } else if ((b >> 4) == 0b1110) {
+                    // 3바이트 문자: 1110xxxx
+                    count = 2;
+                } else if ((b >> 3) == 0b11110) {
+                    // 4바이트 문자: 11110xxx
+                    count = 3;
+                } else {
+                    // 규칙에 맞지 않음
+                    return false;
+                }
+            } else {
+                // 이어지는 바이트는 반드시 10xxxxxx 이어야 함
+                if ((b >> 6) != 0b10) {
+                    return false;
+                }
+                count--;
+            }
+        }
+
+        return count == 0;
+    }
+}


### PR DESCRIPTION

# [393] UTF-8 Validation

## 문제 설명 

Given an integer array `data` representing the data, return whether it is a valid **UTF-8** encoding (i.e. it translates to a sequence of valid UTF-8 encoded characters).

A character in **UTF8** can be from **1 to 4 bytes** long, subjected to the following rules:

1. For a **1-byte** character, the first bit is a `0`, followed by its Unicode code.
2. For an **n-bytes** character, the first `n` bits are all one's, the `n + 1` bit is `0`, followed by `n - 1` bytes with the most significant `2` bits being `10`.

This is how the UTF-8 encoding would work:

>      Number of Bytes   |        UTF-8 Octet Sequence
>                        |              (binary)
>    --------------------+-----------------------------------------
>             1          |   0xxxxxxx
>             2          |   110xxxxx 10xxxxxx
>             3          |   1110xxxx 10xxxxxx 10xxxxxx
>             4          |   11110xxx 10xxxxxx 10xxxxxx 10xxxxxx

`x` denotes a bit in the binary form of a byte that may be either `0` or `1`.

Note: The input is an array of integers. Only the **least significant 8 bits** of each integer is used to store the data. This means each integer represents only 1 byte of data.

 

#### Example 1:

> Input: data = [197,130,1]
> Output: true
> Explanation: data represents the octet sequence: 11000101 10000010 00000001.
> It is a valid utf-8 encoding for a 2-bytes character followed by a 1-byte character.

#### Example 2:

> Input: data = [235,140,4]
> Output: false
> Explanation: data represented the octet sequence: 11101011 10001100 00000100.
> The first 3 bits are all one's and the 4th bit is 0 means it is a 3-bytes character.
> The next byte is a continuation byte which starts with 10 and that's correct.
> But the second continuation byte does not start with 10, so it is invalid.

## 코드 설명

```
class Solution {
    public boolean validUtf8(int[] data) {
        int count = 0; // 현재 검사 중인 문자에서 남은 바이트 수

        for (int num : data) {
            // 하위 8비트만 사용
            int b = num & 0xFF;

            if (count == 0) {
                // 새 문자의 첫 바이트를 만났을 때
                if ((b >> 7) == 0b0) {
                    // 1바이트 문자: 0xxxxxxx
                    count = 0;
                } else if ((b >> 5) == 0b110) {
                    // 2바이트 문자: 110xxxxx
                    count = 1;
                } else if ((b >> 4) == 0b1110) {
                    // 3바이트 문자: 1110xxxx
                    count = 2;
                } else if ((b >> 3) == 0b11110) {
                    // 4바이트 문자: 11110xxx
                    count = 3;
                } else {
                    // 규칙에 맞지 않음
                    return false;
                }
            } else {
                // 이어지는 바이트는 반드시 10xxxxxx 이어야 함
                if ((b >> 6) != 0b10) {
                    return false;
                }
                count--;
            }
        }

        return count == 0;
    }
}
```
#
```
int count = 0;
```
현재 검사 중인 UTF-8 문자의 남은 바이트 수를 기록하는 변수. 처음에는 0(아직 새로운 문자의 시작을 찾는 상태).







```
for (int num : data) {
```
배열을 앞에서부터 한 바이트씩 순회.







```
int b = num & 0xFF;
```
각 정수에서 하위 8비트만 추출. (문제 조건: 각 정수는 실제로는 1바이트 데이터임)







```
if (count == 0) {
```
새로운 UTF-8 문자 시작을 만났을 때.







```
if ((b >> 7) == 0b0) {
```
첫 번째 비트가 0이라면 1바이트 문자 (0xxxxxxx). 남은 바이트 없음 → count = 0.







```
} else if ((b >> 5) == 0b110) {
```
110xxxxx이면 2바이트 문자. 남은 바이트는 1개 → count = 1.







```
} else if ((b >> 4) == 0b1110) {
```
1110xxxx이면 3바이트 문자. 남은 바이트는 2개 → count = 2.







```
} else if ((b >> 3) == 0b11110) {
```
11110xxx이면 4바이트 문자. 남은 바이트는 3개 → count = 3.







```
} else { return false; }
```
위 어떤 패턴에도 맞지 않으면 잘못된 UTF-8 시작 바이트이므로 즉시 false 반환.







```
} else {
```
count != 0 → 지금은 다중 바이트 문자의 뒤이은 바이트를 검사하는 중.







```
if ((b >> 6) != 0b10) { return false; }
```
모든 연속 바이트는 반드시 10xxxxxx 형태여야 함. 아니라면 false.







```
count--;
```
올바른 연속 바이트를 확인했으니, 남은 바이트 개수를 1 줄입니다.







```
return count == 0;
```
마지막에 남은 바이트가 없어야 (count == 0) 전체가 유효한 UTF-8.
만약 중간에 바이트가 덜 왔다면(count > 0) 잘못된 인코딩이므로 false.