### PR TITLE
[416] Partition Equal Subset Sum

### DIFF
--- a/dlek-user/[416] Partition Equal Subset Sum
+++ b/dlek-user/[416] Partition Equal Subset Sum
@@ -1,0 +1,22 @@
+class Solution {
+    public boolean canPartition(int[] nums) {
+        int total = 0;
+        for (int num : nums) {
+            total += num;
+        }
+
+        if (total % 2 != 0) return false;
+
+        int target = total / 2;
+        boolean[] dp = new boolean[target + 1];
+        dp[0] = true; 
+
+        for (int num : nums) {
+            for (int j = target; j >= num; j--) {
+                dp[j] = dp[j] || dp[j - num];
+            }
+        }
+
+        return dp[target];
+    }
+}


### PR DESCRIPTION

# [416] Partition Equal Subset Sum

## 문제 설명 

Given an integer array `nums`, return `true` _if you can partition the array into two subsets such that the sum of the elements in both subsets is equal or_ `false` _otherwise_.

 

#### Example 1:

> Input: nums = [1,5,11,5]
> Output: true
> Explanation: The array can be partitioned as [1, 5, 5] and [11].

#### Example 2:

> Input: nums = [1,2,3,5]
> Output: false
> Explanation: The array cannot be partitioned into equal sum subsets.

## 코드 설명

```
class Solution {
    public boolean canPartition(int[] nums) {
        int total = 0;
        for (int num : nums) {
            total += num;
        }

        if (total % 2 != 0) return false;

        int target = total / 2;
        boolean[] dp = new boolean[target + 1];
        dp[0] = true; 

        for (int num : nums) {
            for (int j = target; j >= num; j--) {
                dp[j] = dp[j] || dp[j - num];
            }
        }

        return dp[target];
    }
}
```
#
```
int total = 0;
```
배열 원소 총합을 저장할 변수 선언.




```
for (int num : nums) { 
    total += num; 
}
```
배열의 모든 원소를 합산하여 total에 저장.




```
if (total % 2 != 0) return false;
```
총합이 홀수라면 절대로 두 부분으로 똑같이 나눌 수 없으므로 false 반환.




```
int target = total / 2;
```
우리가 찾고 싶은 부분집합의 합 = total의 절반.




```
boolean[] dp = new boolean[target + 1];
```
부분합이 0 ~ target까지 가능한지 저장하는 DP 배열.
dp[i] = true이면 합이 i인 부분집합을 만들 수 있다는 뜻.




```
dp[0] = true;
```
합이 0은 항상 빈 집합으로 만들 수 있으므로 true.




```
for (int num : nums) { ... }
```
배열 원소들을 하나씩 확인하면서 부분합 갱신.




```
for (int j = target; j >= num; j--) { ... }
```
target부터 num까지 거꾸로 내려오면서 확인.




```
dp[j] = dp[j] || dp[j - num];
```
현재 num을 사용하지 않아도 이미 dp[j]가 true면 그대로 유지.
만약 dp[j - num]이 true라면 num을 더해서 dp[j]도 true로 만들 수 있음.




```
return dp[target];
```
최종적으로 합이 target이 되는 부분집합이 가능한지 여부 반환.




