### PR TITLE
[808] Soup Servings

### DIFF
--- a/dlek-user/[808] Soup Servings
+++ b/dlek-user/[808] Soup Servings
@@ -1,0 +1,45 @@
+class Solution {
+
+    private Double[][] memo;
+
+    public double soupServings(int n) {
+        if (n > 4800) {
+            return 1.0;
+        }
+
+        int size = (n + 24) / 25;
+
+        memo = new Double[size + 1][size + 1];
+
+        return dfs(size, size);
+    }
+
+    private double dfs(int a, int b) {
+
+        if (a <= 0 && b <= 0) {
+            return 0.5;
+        }
+
+        if (a <= 0) {
+            return 1.0;
+        }
+
+        if (b <= 0) {
+            return 0.0;
+        }
+
+        if (memo[a][b] != null) {
+            return memo[a][b];
+        }
+
+        memo[a][b] =
+                0.25 * (
+                        dfs(a - 4, b) +
+                        dfs(a - 3, b - 1) +
+                        dfs(a - 2, b - 2) +
+                        dfs(a - 1, b - 3)
+                );
+
+        return memo[a][b];
+    }
+}


### PR DESCRIPTION

# [808] Soup Servings

## 문제 설명 

You have two soups, **A** and **B**, each starting with `n` mL. On every turn, one of the following four serving operations is chosen at random, each with probability `0.25` **independent** of all previous turns:

- pour 100 mL from type A and 0 mL from type B
- pour 75 mL from type A and 25 mL from type B
- pour 50 mL from type A and 50 mL from type B
- pour 25 mL from type A and 75 mL from type B

**Note**:

- There is no operation that pours 0 mL from A and 100 mL from B.
- The amounts from A and B are poured simultaneously during the turn.
- If an operation asks you to pour **more than** you have left of a soup, pour all that remains of that soup.

The process stops immediately after any turn in which one of the soups is used up.

Return the probability that A is used up before B, plus half the probability that both soups are used up in the **same turn**. Answers within `10-5` of the actual answer will be accepted.

 

#### Example 1:

> Input: n = 50
> Output: 0.62500
> Explanation: 
> If we perform either of the first two serving operations, soup A will become empty first.
> If we perform the third operation, A and B will become empty at the same time.
> If we perform the fourth operation, B will become empty first.
> So the total probability of A becoming empty first plus half the probability that A and B become empty at the same time, is 0.25 * (1 + 1 + 0.5 + 0) = 0.625.

#### Example 2:

> Input: n = 100
> Output: 0.71875
> Explanation: 
> If we perform the first serving operation, soup A will become empty first.
> If we perform the second serving operations, A will become empty on performing operation [1, 2, 3], and both A and B become empty on performing operation 4.
> If we perform the third operation, A will become empty on performing operation [1, 2], and both A and B become empty on performing operation 3.
> If we perform the fourth operation, A will become empty on performing operation 1, and both A and B become empty on performing operation 2.
> So the total probability of A becoming empty first plus half the probability that A and B become empty at the same time, is 0.71875.

## 코드 설명

```
class Solution {

    private Double[][] memo;

    public double soupServings(int n) {
        if (n > 4800) {
            return 1.0;
        }

        int size = (n + 24) / 25;

        memo = new Double[size + 1][size + 1];

        return dfs(size, size);
    }

    private double dfs(int a, int b) {

        if (a <= 0 && b <= 0) {
            return 0.5;
        }

        if (a <= 0) {
            return 1.0;
        }

        if (b <= 0) {
            return 0.0;
        }

        if (memo[a][b] != null) {
            return memo[a][b];
        }

        memo[a][b] =
                0.25 * (
                        dfs(a - 4, b) +
                        dfs(a - 3, b - 1) +
                        dfs(a - 2, b - 2) +
                        dfs(a - 1, b - 3)
                );

        return memo[a][b];
    }
}
```
#
```
private Double[][] memo;
```
각 상태 (a, b)의 결과를 저장합니다.




```
if (n > 4800) {
    return 1.0;
}
```
문제의 성질상 n이 커질수록 A가 먼저 바닥날 확률은 1에 매우 가까워짐




```
int size = (n + 24) / 25;
```
25mL 단위 변환 올림 나눗셈




```
memo = new Double[size + 1][size + 1];
```
A와 B가 각각 0 ~ size칸 남은 상태를 저장




```
return dfs(size, size);
```
DFS 시작




```
if (a <= 0 && b <= 0)
```
둘 다 동시에 바닥




```
return 0.5;
```
문제 조건에 따라 반환




```
if (a <= 0)
```
A가 먼저 없어졌으므로
return 1.0;




```
if (b <= 0)
```
B가 먼저 없어졌으므로
return 0.0;



```
if (memo[a][b] != null)
```
이전에 계산한 결과를 그대로 사용




```
memo[a][b] =
    0.25 * (
        dfs(a - 4, b) +
        dfs(a - 3, b - 1) +
        dfs(a - 2, b - 2) +
        dfs(a - 1, b - 3)
    );
```
현재 상태에서 가능한 4개의 연산은 모두 동일한 확률(25%)이므로,
각 결과의 평균을 구하기
